### PR TITLE
Update ar0903_e.baf

### DIFF
--- a/Sirene_BG2/scripts/ar0903_e.baf
+++ b/Sirene_BG2/scripts/ar0903_e.baf
@@ -1,5 +1,5 @@
 IF
-  Global("C0SireneSpawns","GLOBAL",0)
+  Global("C0SireneSpawns","AR0903",0)
   BeenInParty("C0Sirene")
   GlobalLT("chapter","GLOBAL",20)
   !StateCheck("C0Sirene",STATE_REALLY_DEAD)
@@ -26,12 +26,21 @@ THEN
     ActionOverride("C0Sirene",CreateItem("POTN14",1,0,0)) //Oil of Speed
     ActionOverride("C0Sirene",CreateItem("C02AMUL",1,0,0)) //Painbearer's Amulet
     ActionOverride("C0Sirene",FillSlot(SLOT_AMULET))
-    SetGlobal("C0SireneSpawns","GLOBAL",1)
+    SetGlobal("C0SireneSpawns","AR0903",1)
+    SetGlobal("C0SireneDorn","GLOBAL",0)
+    SetGlobal("C0SireneDornConflict","GLOBAL",0)
+    SetGlobal("C0SireneDornConflictTimer","GLOBAL",0)
+    SetGlobal("C0SireneJoined","GLOBAL",0)
+    SetGlobal("C0SireneLowRep","GLOBAL",0)
+    SetGlobal("C0SireneMatch","GLOBAL",0)
+    SetGlobal("C0SireneNeera1","GLOBAL",0)
+    SetGlobal("C0SireneRasaad1","GLOBAL",0)
+    SetGlobal("C0SireneRepBreak","GLOBAL",0)
     Continue()
 END
 
 IF
-  Global("C0SireneSpawns","GLOBAL",0)
+  Global("C0SireneSpawns","AR0903",0)
   !BeenInParty("C0Sirene")
   GlobalLT("chapter","GLOBAL",20)
   !StateCheck("C0Sirene",STATE_REALLY_DEAD)
@@ -39,6 +48,6 @@ THEN
   RESPONSE #100
     CreateCreature("C0SIRE2",[733.1334],14)
     ActionOverride("C0Sirene",MakeGlobalOverride())
-    SetGlobal("C0SireneSpawns","GLOBAL",1)
+    SetGlobal("C0SireneSpawns","AR0903",1)
     Continue()
 END


### PR DESCRIPTION
https://forums.beamdog.com/discussion/62163/npc-mod-sirene-npc-for-bg2-ee-v1-4/p5
Changed global variable into area variable to avoid conflict with BG:EE Sirene. Other conflicting variable names are reset to 0 if player had Sirene during BG:EE (remove them if any of those variables should keep the value after transition for continuity sake).